### PR TITLE
Fix #5 Added support for Python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.3.0
+* Added support for Python3 due to Python2.x deprecation
+
 # v0.2.0
 * Provider is now one file, for easier distribution
 

--- a/ring.py
+++ b/ring.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Added support for Python3.

Tested on Python 3.7 using Summon v0.8.0 successfully.

Updated [CHANGELOG.md](CHANGELOG.md) to include v0.3.0 for this change.