### PR TITLE
Fix inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and the "Password" field should contain the secret value.
 Now we can fetch it with summon by using this provider.
 
 ```sh-session
-$ summon -p ring.py --yaml 'MYSECRET: !var secret/path' printenv MYSECRET
+$ summon -p keyring.py --yaml 'MYSECRET: !var secret/path' printenv MYSECRET
 secretvalue
 ```
 


### PR DESCRIPTION
The Install section steps set the provider name to `keyring.py`, but the the example steps refer to the provider as `ring.py`. I updated this so it is consistent.