### PR TITLE
Update repo URL for this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can install by simply cloning the repo and creating a symlink in the
 You may need to run the following commands as a super user.
 
 ```sh-session
-$ git clone git@github.com:conjurinc/summon-keyring.git
+$ git clone git@github.com:cyberark/summon-keyring.git
 $ cd summon-keyring
 $ mkdir -p /usr/local/lib/summon
 $ ln -s "$PWD/ring.py" /usr/local/lib/summon/keyring.py


### PR DESCRIPTION
It still referenced the old repo name, `conjurinc/summon-keyring`

This commit updates it to `cyberark/summon-keyring`

Partially resolves #15 